### PR TITLE
Feature/auth middleware

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -1,0 +1,4 @@
+# gRPC Auth Interceptor
+
+Package `grpc_auther` provides an easy way to hook Bearer-token and TLS credentials authorization to your gRPC server.
+

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+/*
+Package `grpc_auther` provides an easy way to hook Bearer-token and TLS credentials authorization to your gRPC server.
+
+*/
+
+package grpc_auth
+
+import (
+	"github.com/mwitkow/go-grpc-middleware"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// AuthFunc is the pluggable function that performs authentication.
+// The passed in `Context` will contain the gRPC metadata.MD object (for header-based authentication) and
+// the peer.Peer information that can contain transport-based credentials (e.g. `credentials.AuthInfo`).
+// The returned context will be propagated to handlers, allowing user changes to `Context`. However,
+// please make sure that the `Context` returned is a child `Context` of the one passed in.
+// If error is returned, its `grpc.Code()` will be returned to the user as well as the verbatim message.
+// Please make sure you use `codes.Unauthenticated` (lacking auth) and `codes.PermissionDenied`
+// (authed, but lacking perms) appropriately.
+type AuthFunc func(ctx context.Context) (context.Context, error)
+
+// ServiceAuthFuncOverride allows a given gRPC service implementation to override the global `AuthFunc`.
+// If a service implements the AuthFuncOverride method, it takes precedence over the `AuthFunc` method,
+// and will be called instead of AuthFunc for all method invocations within that service.
+type ServiceAuthFuncOverride interface {
+	AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error)
+}
+
+// UnaryServerInterceptor returns a new unary server interceptors that performs per-request auth.
+func UnaryServerInterceptor(authFunc AuthFunc) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		var newCtx context.Context
+		var err error
+		if overrideSrv, ok := info.Server.(ServiceAuthFuncOverride); ok {
+			newCtx, err = overrideSrv.AuthFuncOverride(ctx, info.FullMethod)
+		} else {
+			newCtx, err = authFunc(ctx)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return handler(newCtx, req)
+	}
+}
+
+// StreamServerInterceptor returns a new unary server interceptors that performs per-request auth.
+func StreamServerInterceptor(authFunc AuthFunc) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		var newCtx context.Context
+		var err error
+		if overrideSrv, ok := srv.(ServiceAuthFuncOverride); ok {
+			newCtx, err = overrideSrv.AuthFuncOverride(stream.Context(), info.FullMethod)
+		} else {
+			newCtx, err = authFunc(stream.Context())
+		}
+		if err != nil {
+			return nil, err
+		}
+		wrapped := grpc_middleware.WrapServerStream(stream)
+		wrapped.WrappedContext = newCtx
+		return handler(srv, wrapped)
+	}
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,7 +3,6 @@
 
 /*
 Package `grpc_auther` provides an easy way to hook Bearer-token and TLS credentials authorization to your gRPC server.
-
 */
 
 package grpc_auth
@@ -59,7 +58,7 @@ func StreamServerInterceptor(authFunc AuthFunc) grpc.StreamServerInterceptor {
 			newCtx, err = authFunc(stream.Context())
 		}
 		if err != nil {
-			return nil, err
+			return err
 		}
 		wrapped := grpc_middleware.WrapServerStream(stream)
 		wrapped.WrappedContext = newCtx

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,170 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+
+	"fmt"
+
+	"github.com/mwitkow/go-grpc-middleware/auth"
+	"github.com/mwitkow/go-grpc-middleware/testing"
+	pb_testproto "github.com/mwitkow/go-grpc-middleware/testing/testproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	commonAuthToken   = "some_good_token"
+	overrideAuthToken = "override_token"
+
+	authedMarker = "some_context_marker"
+	goodPing     = &pb_testproto.PingRequest{Value: "something", SleepTimeMs: 9999}
+)
+
+// TODO(mwitkow): Add auth from metadata client dialer, which requires TLS.
+
+func buildDummyAuthFunction(expectedScheme string, expectedToken string) func(ctx context.Context) (context.Context, error) {
+	return func(ctx context.Context) (context.Context, error) {
+		token, err := grpc_auth.AuthFromMD(ctx, expectedScheme)
+		if err != nil {
+			return nil, err
+		}
+		if token != expectedToken {
+			return nil, grpc.Errorf(codes.PermissionDenied, "buildDummyAuthFunction bad token")
+		}
+		return context.WithValue(ctx, authedMarker, "marker_exists"), nil
+	}
+}
+
+func assertAuthMarkerExists(t *testing.T, ctx context.Context) {
+	assert.Equal(t, "marker_exists", ctx.Value(authedMarker).(string), "auth marker from buildDummyAuthFunction must be passed around")
+}
+
+type assertingPingService struct {
+	pb_testproto.TestServiceServer
+	T *testing.T
+}
+
+func (s *assertingPingService) PingError(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.Empty, error) {
+	assertAuthMarkerExists(s.T, ctx)
+	return s.TestServiceServer.PingError(ctx, ping)
+}
+
+func (s *assertingPingService) PingList(ping *pb_testproto.PingRequest, stream pb_testproto.TestService_PingListServer) error {
+	assertAuthMarkerExists(s.T, stream.Context())
+	return s.TestServiceServer.PingList(ping, stream)
+}
+
+func ctxWithToken(ctx context.Context, scheme string, token string) context.Context {
+	md := metadata.Pairs("authorization", fmt.Sprintf("%s %v", scheme, token))
+	nCtx := metadata.NewContext(ctx, md)
+	return nCtx
+}
+
+func TestAuthTestSuite(t *testing.T) {
+	authFunc := buildDummyAuthFunction("bearer", commonAuthToken)
+	s := &AuthTestSuite{
+		InterceptorTestSuite: &grpc_testing.InterceptorTestSuite{
+			TestService: &assertingPingService{&grpc_testing.TestPingService{T: t}, t},
+			ServerOpts: []grpc.ServerOption{
+				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authFunc)),
+				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(authFunc)),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+type AuthTestSuite struct {
+	*grpc_testing.InterceptorTestSuite
+}
+
+func (s *AuthTestSuite) TestUnary_NoAuth() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	assert.Error(s.T(), err, "there must be an error")
+	assert.Equal(s.T(), codes.Unauthenticated, grpc.Code(err), "must error with unauthenticated")
+}
+
+func (s *AuthTestSuite) TestUnary_BadAuth() {
+	_, err := s.Client.Ping(ctxWithToken(s.SimpleCtx(), "bearer", "bad_token"), goodPing)
+	assert.Error(s.T(), err, "there must be an error")
+	assert.Equal(s.T(), codes.PermissionDenied, grpc.Code(err), "must error with permission denied")
+}
+
+func (s *AuthTestSuite) TestUnary_PassesAuth() {
+	_, err := s.Client.Ping(ctxWithToken(s.SimpleCtx(), "bearer", commonAuthToken), goodPing)
+	require.NoError(s.T(), err, "no error must occur")
+}
+
+func (s *AuthTestSuite) TestStream_NoAuth() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	_, err = stream.Recv()
+	assert.Error(s.T(), err, "there must be an error")
+	assert.Equal(s.T(), codes.Unauthenticated, grpc.Code(err), "must error with unauthenticated")
+}
+
+func (s *AuthTestSuite) TestStream_BadAuth() {
+	stream, err := s.Client.PingList(ctxWithToken(s.SimpleCtx(), "bearer", "bad_token"), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	_, err = stream.Recv()
+	assert.Error(s.T(), err, "there must be an error")
+	assert.Equal(s.T(), codes.PermissionDenied, grpc.Code(err), "must error with permission denied")
+}
+
+func (s *AuthTestSuite) TestStream_PassesAuth() {
+	stream, err := s.Client.PingList(ctxWithToken(s.SimpleCtx(), "Bearer", commonAuthToken), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	pong, err := stream.Recv()
+	require.NoError(s.T(), err, "no error must occur")
+	require.NotNil(s.T(), pong, "pong must not be nil")
+}
+
+type authOverrideTestService struct {
+	pb_testproto.TestServiceServer
+	T *testing.T
+}
+
+func (s *authOverrideTestService) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	assert.NotEmpty(s.T, fullMethodName, "method name of caller is passed around")
+	return buildDummyAuthFunction("bearer", overrideAuthToken)(ctx)
+}
+
+func TestAuthOverrideTestSuite(t *testing.T) {
+	authFunc := buildDummyAuthFunction("bearer", commonAuthToken)
+	s := &AuthOverrideTestSuite{
+		InterceptorTestSuite: &grpc_testing.InterceptorTestSuite{
+			TestService: &authOverrideTestService{&assertingPingService{&grpc_testing.TestPingService{T: t}, t}, t},
+			ServerOpts: []grpc.ServerOption{
+				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authFunc)),
+				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(authFunc)),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+type AuthOverrideTestSuite struct {
+	*grpc_testing.InterceptorTestSuite
+}
+
+func (s *AuthOverrideTestSuite) TestUnary_PassesAuth() {
+	_, err := s.Client.Ping(ctxWithToken(s.SimpleCtx(), "bearer", overrideAuthToken), goodPing)
+	require.NoError(s.T(), err, "no error must occur")
+}
+
+func (s *AuthOverrideTestSuite) TestStream_PassesAuth() {
+	stream, err := s.Client.PingList(ctxWithToken(s.SimpleCtx(), "Bearer", overrideAuthToken), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	pong, err := stream.Recv()
+	require.NoError(s.T(), err, "no error must occur")
+	require.NotNil(s.T(), pong, "pong must not be nil")
+}

--- a/auth/metadata.go
+++ b/auth/metadata.go
@@ -1,0 +1,40 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_auth
+
+import (
+	"google.golang.org/grpc/metadata"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"strings"
+)
+
+
+var (
+	headerAuthorize = ":authorization"
+)
+
+// AuthFromMD is a helper function for extracting the :authorization header from the gRPC metadata of the request.
+// It expets the :authorization header to be of a certain scheme (e.g. `basic`, `bearer`), in a
+// case-insensitive format (see rfc2617, sec 1.2). If no such authorization is found, or the token
+// is of wrong scheme, an error with gRPC status Unauthenticated is returned.
+func AuthFromMD(ctx context.Context, expectedScheme string) (string, error) {
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		return "", grpc.Errorf(codes.Internal, "gRPC context lacks metadata")
+	}
+	slice, ok := md[headerAuthorize]
+	if !ok {
+		return "", grpc.Errorf(codes.Unauthenticated, "Request unauthenticated with " + expectedScheme)
+	}
+	if len(slice) > 1 {
+		return "", grpc.Errorf(codes.Unauthenticated, "Request contains multiple authorization headers")
+	}
+	splits := strings.SplitN(slice[0], " ", 2)
+	if strings.ToLower(splits[0]) != strings.ToLower(expectedScheme) {
+		return "", grpc.Errorf(codes.Unauthenticated, "Request unauthenticated with " + expectedScheme)
+	}
+	return splits[1], nil
+}

--- a/auth/metadata.go
+++ b/auth/metadata.go
@@ -13,7 +13,7 @@ import (
 
 
 var (
-	headerAuthorize = ":authorization"
+	headerAuthorize = "authorization"
 )
 
 // AuthFromMD is a helper function for extracting the :authorization header from the gRPC metadata of the request.

--- a/auth/metadata_test.go
+++ b/auth/metadata_test.go
@@ -1,0 +1,58 @@
+package grpc_auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestAuthFromMD(t *testing.T) {
+	for _, run := range []struct {
+		md      metadata.MD
+		value   string
+		errCode codes.Code
+		msg     string
+	}{
+		{
+			md:    metadata.Pairs(":authorization", "bearer some_token"),
+			value: "some_token",
+			msg:   "must extract simple bearer tokens without case checking",
+		},
+		{
+			md:    metadata.Pairs(":authorization", "Bearer some_token"),
+			value: "some_token",
+			msg:   "must extract simple bearer tokens with case checking",
+		},
+		{
+			md:    metadata.Pairs(":authorization", "Bearer some multi string bearer"),
+			value: "some multi string bearer",
+			msg:   "must handle string based bearers",
+		},
+		{
+			md:      metadata.Pairs(":authorization", "Basic login:passwd"),
+			value:   "",
+			errCode: codes.Unauthenticated,
+			msg:     "must check authentication type",
+		},
+		{
+			md:      metadata.Pairs(":authorization", "Basic login:passwd", ":authorization", "bearer some_token"),
+			value:   "",
+			errCode: codes.Unauthenticated,
+			msg:     "must not allow multiple authentication methods",
+		},
+	} {
+		ctx := metadata.NewContext(context.TODO(), run.md)
+		out, err := AuthFromMD(ctx, "bearer")
+		if run.errCode != codes.OK {
+			assert.Equal(t, run.errCode, grpc.Code(err), run.msg)
+		} else {
+			assert.NoError(t, err, run.msg)
+		}
+		assert.Equal(t, run.value, out, run.msg)
+	}
+
+}

--- a/auth/metadata_test.go
+++ b/auth/metadata_test.go
@@ -18,28 +18,28 @@ func TestAuthFromMD(t *testing.T) {
 		msg     string
 	}{
 		{
-			md:    metadata.Pairs(":authorization", "bearer some_token"),
+			md:    metadata.Pairs("authorization", "bearer some_token"),
 			value: "some_token",
 			msg:   "must extract simple bearer tokens without case checking",
 		},
 		{
-			md:    metadata.Pairs(":authorization", "Bearer some_token"),
+			md:    metadata.Pairs("authorization", "Bearer some_token"),
 			value: "some_token",
 			msg:   "must extract simple bearer tokens with case checking",
 		},
 		{
-			md:    metadata.Pairs(":authorization", "Bearer some multi string bearer"),
+			md:    metadata.Pairs("authorization", "Bearer some multi string bearer"),
 			value: "some multi string bearer",
 			msg:   "must handle string based bearers",
 		},
 		{
-			md:      metadata.Pairs(":authorization", "Basic login:passwd"),
+			md:      metadata.Pairs("authorization", "Basic login:passwd"),
 			value:   "",
 			errCode: codes.Unauthenticated,
 			msg:     "must check authentication type",
 		},
 		{
-			md:      metadata.Pairs(":authorization", "Basic login:passwd", ":authorization", "bearer some_token"),
+			md:      metadata.Pairs("authorization", "Basic login:passwd", "authorization", "bearer some_token"),
 			value:   "",
 			errCode: codes.Unauthenticated,
 			msg:     "must not allow multiple authentication methods",

--- a/testing/interceptor_suite.go
+++ b/testing/interceptor_suite.go
@@ -12,7 +12,13 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"flag"
 )
+
+var (
+	flagTls = flag.Bool("use_tls", false, "whether all gRPC middleware tests should use tls")
+)
+
 
 // InterceptorTestSuite is a testify/Suite that starts a gRPC PingService server and a client.
 type InterceptorTestSuite struct {
@@ -64,8 +70,9 @@ func (s *InterceptorTestSuite) SimpleCtx() context.Context {
 }
 
 func (s *InterceptorTestSuite) TearDownSuite() {
+	time.Sleep(10 * time.Millisecond)
 	if s.ServerListener != nil {
-		s.Server.Stop()
+		s.Server.GracefulStop()
 		s.T().Logf("stopped grpc.Server at: %v", s.ServerAddr())
 		s.ServerListener.Close()
 


### PR DESCRIPTION
Adds auth middleware with a service override test.

The only thing lacking here is support for OAuth2 PerRPCCredentials, but that's because we don't have TLS in the harness.